### PR TITLE
TTFInstructions.hs: fix layout for Haskell2010

### DIFF
--- a/TTFInstructions.hs
+++ b/TTFInstructions.hs
@@ -126,8 +126,8 @@ _tableDef tag checkSum offset len
 
 tableChecksum table =
     let tc = do
-        e <- remaining
-        if e < 4
+          e <- remaining
+          if e < 4
             then return 0
             else do w <- getWord32be
                     r <- tc


### PR DESCRIPTION
Noticed missing extension when bundled ttasm source into QuickFuzz.
Build failed as:

  [1 of 1] Compiling TTFInstructions  ( TTFInstructions.hs, dist/build/TTFInstructions.o ) [flags changed]

  TTFInstructions.hs:129:11: error:
    parse error on input ‘<-’
    Perhaps this statement should be within a 'do' block?

The error comes from the fact that QuickFuzz is built as
-XHaskell2010 while ttasm's default is -XHaskell98.

In Haskell98 mode ghc is less strict about enforcing layout rule
(for now):

```
https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/bugs.html#context-free-syntax
```

Change makes layout more future-proof with nonambiguous indentation.

Signed-off-by: Sergei Trofimovich siarheit@google.com
